### PR TITLE
Fast Index Access (without traces)

### DIFF
--- a/pluthon/optimize/constant_index_access_list.py
+++ b/pluthon/optimize/constant_index_access_list.py
@@ -2,7 +2,7 @@ from pluthon import IndexAccessList, Integer, ConstantIndexAccessList
 from pluthon.util import NodeTransformer
 
 
-class IndexAccessOptimizer(NodeTransformer):
+class ConstantIndexAccessOptimizer(NodeTransformer):
     """
     Replaces IndexAccesses to constants with ConstantIndexAccesses
     """

--- a/pluthon/optimize/fast_index_access_list.py
+++ b/pluthon/optimize/fast_index_access_list.py
@@ -1,0 +1,20 @@
+from pluthon import (
+    IndexAccessList,
+    Integer,
+    ConstantIndexAccessList,
+    UnsafeConstantIndexAccessList,
+    UnsafeIndexAccessList,
+)
+from pluthon.util import NodeTransformer
+
+
+class FastIndexAccessOptimizer(NodeTransformer):
+    """
+    Replaces IndexAccesses to constants with ConstantIndexAccesses
+    """
+
+    def visit_IndexAccessList(self, node: IndexAccessList):
+        return UnsafeIndexAccessList(node.l, node.i)
+
+    def visit_ConstantIndexAccessList(self, node: ConstantIndexAccessList):
+        return UnsafeConstantIndexAccessList(node.l, node.i)

--- a/pluthon/tools.py
+++ b/pluthon/tools.py
@@ -1,12 +1,15 @@
 from uplc.ast import Program as UPLCProgram
 
-from .optimize.constant_index_access_list import IndexAccessOptimizer
 from .optimize.patterns import OncePatternReplacer
+from .optimize.constant_index_access_list import ConstantIndexAccessOptimizer
+from .optimize.fast_index_access_list import FastIndexAccessOptimizer
 from .pluthon_ast import Program, AST
 from .util import NoOp
 
 
-def compile(x: Program, optimize_patterns=True) -> UPLCProgram:
+def compile(
+    x: Program, optimize_patterns=True, unsafe_index_access=False
+) -> UPLCProgram:
     """
     Returns compiles Pluto code in UPLC
     :param x: the program to compile
@@ -19,7 +22,8 @@ def compile(x: Program, optimize_patterns=True) -> UPLCProgram:
     while x_new_dumps != x_old_dumps:
         x_old_dumps = x_new_dumps
         for step in [
-            IndexAccessOptimizer(),
+            ConstantIndexAccessOptimizer(),
+            FastIndexAccessOptimizer() if unsafe_index_access else NoOp(),
             OncePatternReplacer() if optimize_patterns else NoOp(),
         ]:
             x = step.visit(x)


### PR DESCRIPTION
This adds list index access that does not log an index error on failure but prints a more obscure "trying to apply headlist to null list"-ish error. It should only be used for -O3 type of optimizations.