### PR TITLE
Inline singleton occurrences of patterns

### DIFF
--- a/pluthon/pluthon_ast.py
+++ b/pluthon/pluthon_ast.py
@@ -252,4 +252,4 @@ class Pattern(AST):
         return self.compose().compile()
 
     def dumps(self) -> str:
-        return self.compose().dumps()
+        return f"<[{self.__class__.__name__}]> {self.compose().dumps()}"

--- a/pluthon/pluthon_sugar.py
+++ b/pluthon/pluthon_sugar.py
@@ -270,7 +270,7 @@ class EmptyList(AST):
             return f"Pair<{EmptyList(self.sample_value.l_value).mk_nil_suffix()}|{EmptyList(self.sample_value.r_value).mk_nil_suffix()}>"
         if isinstance(self.sample_value, uplc_ast.BuiltinList):
             return f"List{EmptyList(self.sample_value.sample_value).mk_nil_suffix()}"
-        return self.sample_value.__class__
+        return self.sample_value.__class__.__name__
 
     def dumps(self) -> str:
         # Note: this is not a real builtin. Essentially, this is not pluto


### PR DESCRIPTION
Currently all functions are patternized if possible. However, it may happen that this strictly worsens the size and cost of the resulting script - precisely when a pattern occurs only once in the code. In these cases, it is better to inline the pattern. This change makes sure that patterns occuring only once are always inlined.