### PR TITLE
Add a proper configuration object to Pluthon

### DIFF
--- a/pluthon/__init__.py
+++ b/pluthon/__init__.py
@@ -8,6 +8,7 @@ try:
     from .pluthon_sugar import *
     from .pluthon_functional_data import *
     from .tools import *
+    from .compiler_config import *
 except ImportError as e:
     logging.error(
         "Error, trying to import dependencies. Should only occur upon package installation",

--- a/pluthon/__init__.py
+++ b/pluthon/__init__.py
@@ -15,7 +15,7 @@ except ImportError as e:
         exc_info=e,
     )
 
-VERSION = (0, 4, 10)
+VERSION = (0, 5, 0)
 
 __version__ = ".".join([str(i) for i in VERSION])
 __author__ = "nielstron"

--- a/pluthon/compiler_config.py
+++ b/pluthon/compiler_config.py
@@ -1,0 +1,58 @@
+from dataclasses import dataclass
+from typing import Optional, Union
+
+
+@dataclass(frozen=True)
+class CompilationConfig:
+    compress_patterns: Optional[bool] = None
+    iterative_unfold_patterns: Optional[bool] = None
+    constant_index_access_list: Optional[bool] = None
+
+    def update(
+        self, other: Optional["CompilationConfig"] = None, **kwargs
+    ) -> "CompilationConfig":
+        own_dict = self.__dict__
+        other_dict = other.__dict__ if isinstance(other, CompilationConfig) else kwargs
+        return self.__class__(
+            **{
+                k: other_dict.get(k) if other_dict.get(k) is not None else own_dict[k]
+                for k in own_dict
+            }
+        )
+
+
+# The default configuration for the compiler
+OPT_O0_CONFIG = CompilationConfig(
+    compress_patterns=False,
+    iterative_unfold_patterns=False,
+)
+OPT_O1_CONFIG = OPT_O0_CONFIG.update(
+    compress_patterns=True,
+    constant_index_access_list=True,
+)
+OPT_O2_CONFIG = OPT_O1_CONFIG.update()
+OPT_O3_CONFIG = OPT_O2_CONFIG.update(
+    iterative_unfold_patterns=True,
+)
+OPT_CONFIGS = [OPT_O0_CONFIG, OPT_O1_CONFIG, OPT_O2_CONFIG, OPT_O3_CONFIG]
+
+DEFAULT_CONFIG = CompilationConfig().update(OPT_O1_CONFIG)
+
+ARGPARSE_ARGS = {
+    "compress_patterns": {
+        "action": "store_true",
+        "help": "Enables the compression of re-occurring code patterns. Can reduce memory and CPU steps but increases the size of the compiled contract.",
+    },
+    "iterative_unfold_patterns": {
+        "action": "store_true",
+        "help": "Enables iterative unfolding of patterns. Improves application of pattern optimization but is very slow.",
+    },
+    "constant_index_access_list": {
+        "action": "store_true",
+        "help": "Replace index accesses with constant parameters with optimized constant accesses. Can reduce memory and CPU steps but increases the size of the compiled contract.",
+    },
+}
+for k in ARGPARSE_ARGS:
+    assert (
+        k in DEFAULT_CONFIG.__dict__
+    ), f"Key {k} not found in CompilationConfig.__dict__"

--- a/pluthon/optimize/constant_index_access_list.py
+++ b/pluthon/optimize/constant_index_access_list.py
@@ -4,6 +4,10 @@ from pluthon.pluthon_sugar import (
     ConstantIndexAccessList,
     NthField,
     ConstantNthField,
+    IndexAccessListFast,
+    ConstantIndexAccessListFast,
+    NthFieldFast,
+    ConstantNthFieldFast,
 )
 from pluthon.util import NodeTransformer
 
@@ -21,4 +25,14 @@ class IndexAccessOptimizer(NodeTransformer):
     def visit_NthField(self, node: NthField):
         if isinstance(node.n, Integer):
             return ConstantNthField(node.d, node.n.x)
+        return node
+
+    def visit_IndexAccessListFast(self, node: IndexAccessListFast):
+        if isinstance(node.i, Integer):
+            return ConstantIndexAccessListFast(node.l, node.i.x)
+        return node
+
+    def visit_NthFieldFast(self, node: NthFieldFast):
+        if isinstance(node.n, Integer):
+            return ConstantNthFieldFast(node.d, node.n.x)
         return node

--- a/pluthon/pluthon_sugar.py
+++ b/pluthon/pluthon_sugar.py
@@ -929,6 +929,15 @@ class NthField(Pattern):
         return IndexAccessList(Fields(self.d), self.n)
 
 
+@dataclass
+class NthFieldFast(Pattern):
+    d: AST
+    n: AST
+
+    def compose(self):
+        return IndexAccessListFast(Fields(self.d), self.n)
+
+
 def ConstantNthField(d: AST, i: int):
     return ConstantIndexAccessList(Fields(d), i)
 

--- a/pluthon/tools.py
+++ b/pluthon/tools.py
@@ -1,5 +1,6 @@
 from uplc.ast import Program as UPLCProgram
 
+from .compiler_config import DEFAULT_CONFIG
 from .optimize.constant_index_access_list import IndexAccessOptimizer
 from .optimize.patterns import OncePatternReplacer, AllPatternReplacer
 from .pluthon_ast import Program, AST
@@ -7,7 +8,8 @@ from .util import NoOp
 
 
 def compile(
-    x: Program, optimize_patterns=True, iterative_unfold_patterns=False
+    x: Program,
+    config=DEFAULT_CONFIG,
 ) -> UPLCProgram:
     """
     Returns compiles Pluto code in UPLC
@@ -21,13 +23,13 @@ def compile(
     while x_new_dumps != x_old_dumps:
         x_old_dumps = x_new_dumps
         for step in [
-            IndexAccessOptimizer(),
+            IndexAccessOptimizer() if config.constant_index_access_list else NoOp(),
             (
                 OncePatternReplacer()
-                if iterative_unfold_patterns
+                if config.iterative_unfold_patterns
                 else AllPatternReplacer()
             )
-            if optimize_patterns
+            if config.compress_patterns
             else NoOp(),
         ]:
             x = step.visit(x)


### PR DESCRIPTION
This fixes https://github.com/OpShin/opshin/issues/267 and https://github.com/OpShin/opshin/issues/168 by adding a proper configuration object to both Pluthon and OpShin (and future also UPLC). This configuration object is more easy to handle and expand with language and tooling specific parameters. All parameters of the configuration object can be overwritten by passing dedicated flags. This opens the avenue to enable additional optimizations such as #14 or #16  as well as giving more fine-grained options for debugging code (i.e. allowing to disable removal of unused variables)