### PR TITLE
Bump uplc to 1.0.4

### DIFF
--- a/pluthon/pluthon_ast.py
+++ b/pluthon/pluthon_ast.py
@@ -166,7 +166,7 @@ class UPLCConstant(AST):
         return self.x
 
     def dumps(self) -> str:
-        return f"uplc[{self.x.dumps(dialect=uplc_ast.UPLCDialect.Aiken)}]"
+        return f"uplc[{self.x.dumps(dialect=uplc_ast.UPLCDialect.LegacyAiken)}]"
 
 
 @dataclass

--- a/setup.py
+++ b/setup.py
@@ -25,8 +25,8 @@ setup(
     py_modules=["uplc"],
     packages=find_packages(),
     install_requires=[
-        "uplc>=0.6.2",
-        "uplc<0.7.0",
+        "uplc>=1.0.4",
+        "uplc<1.1.0",
         'graphlib-backport>=1.0.0; python_version<"3.9"',
         "ordered-set>=4.1.0",
         "ordered-set<5.0.0",


### PR DESCRIPTION
Hi! I'm maintaining opshin package in [nixpkgs](https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/op/opshin/package.nix) but unfortunately after bumping `uplc` in nixpkgs it doesn't compile anymore. Would you mind bumping `uplc` here as well?